### PR TITLE
Support Generating HTTPS /docs urls automatically based on requesting schema

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -48,7 +48,7 @@ $app->get(config('swagger-lume.routes.api'), function () {
         view('swagger-lume::index', [
             'apiTitle'       => config('swagger-lume.api.title'),
             'secure'         => (new Request())->secure(),
-            'urlToDocs'      => url(config('swagger-lume.routes.docs')),
+            'urlToDocs'      => url(config('swagger-lume.routes.docs'), [], (new Request())->secure()),
             'requestHeaders' => config('swagger-lume.headers.request'),
             'docExpansion'       => config('swagger-lume.docExpansion'),
             'highlightThreshold' => config('swagger-lume.highlightThreshold'),


### PR DESCRIPTION
URLs generated by the doc viewer do not support generating https urls on https served domains automatically. This enables that functionality.